### PR TITLE
Fix appveyor requirements install

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,11 +35,10 @@ install:
     - cmd: git clone https://github.com/fatiando/continuous-integration.git
     # Setup miniconda and install the requirements into a new environment
     #- cmd: continuous-integration\appveyor\setup-miniconda.bat
+    # We'll use the current script in this repo but you should use the above line
     - cmd: appveyor\setup-miniconda.bat
     # Activate the new environment
     - cmd: activate testing
-    # Update pip in the testing environment
-    - cmd: python -m pip install --upgrade pip
     # Show installed pkg information for postmortem diagnostic
     - cmd: conda list
     # Make a source package for the project and install it

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,9 +34,12 @@ install:
     # Get the Fatiando CI scripts
     - cmd: git clone https://github.com/fatiando/continuous-integration.git
     # Setup miniconda and install the requirements into a new environment
-    - cmd: continuous-integration\appveyor\setup-miniconda.bat
+    #- cmd: continuous-integration\appveyor\setup-miniconda.bat
+    - cmd: appveyor\setup-miniconda.bat
     # Activate the new environment
     - cmd: activate testing
+    # Update pip in the testing environment
+    - cmd: python -m pip install --upgrade pip
     # Show installed pkg information for postmortem diagnostic
     - cmd: conda list
     # Make a source package for the project and install it

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,4 +47,4 @@ install:
 
 test_script:
     # Run the tests inside a tmp folder to make sure we're testing the installed version
-    - ps: mkdir -p tmp; cd tmp; python -c "assert True"
+    - ps: mkdir -p tmp; cd tmp; python -c "import numpy; assert True"

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -1,6 +1,12 @@
 REM Configure and update conda, then install the dependencies into a new environment
 REM using the file specified in the CONDA_REQUIREMENTS variable.
 
+REM Enable extensions to use the IF DEFINED command
+REM From http://www.robvanderwoude.com/battech_defined.php
+VERIFY OTHER 2>nul
+SETLOCAL ENABLEEXTENSIONS
+IF ERRORLEVEL 1 ECHO Unable to enable extensions
+
 REM Don't change the prompt or request user input
 conda config --set always_yes yes --set changeps1 no
 
@@ -19,3 +25,5 @@ activate testing
 ECHO Installing requirements from file
 ECHO ===============================================
 IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)
+
+ENDLOCAL

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -24,18 +24,17 @@ ECHO.
 ECHO Creating the 'testing' environment
 ECHO ===============================================
 conda create --quiet --name testing python="%PYTHON%" pip
+REM Need to use call in batch scripts: https://github.com/conda/conda/issues/794
+call activate testing
 
 ECHO.
 ECHO Updating pip
 ECHO ===============================================
-REM Need to use call in batch scripts: https://github.com/conda/conda/issues/794
-call activate testing
 python -m pip install --upgrade pip
-call deactivate
 
 ECHO.
 ECHO Installing requirements from file
 ECHO ===============================================
-IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --name testing --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)
+IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)
 
 ENDLOCAL

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -20,10 +20,9 @@ conda update --quiet conda
 ECHO Creating the 'testing' environment
 ECHO ===============================================
 conda create --quiet --name testing python="%PYTHON%" pip
-activate testing
 
 ECHO Installing requirements from file
 ECHO ===============================================
-IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)
+IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --name testing --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)
 
 ENDLOCAL

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -7,7 +7,7 @@ VERIFY OTHER 2>nul
 SETLOCAL ENABLEEXTENSIONS
 IF ERRORLEVEL 1 ECHO Unable to enable extensions
 
-ECHO
+ECHO.
 ECHO Configuring conda
 ECHO ===============================================
 REM Don't change the prompt or request user input
@@ -15,24 +15,24 @@ conda config --set always_yes yes --set changeps1 no
 REM Add conda-forge to the top of the channel list
 conda config --add channels conda-forge
 
-ECHO
+ECHO.
 ECHO Updating conda
 ECHO ===============================================
 conda update --quiet conda
 
-ECHO
+ECHO.
 ECHO Creating the 'testing' environment
 ECHO ===============================================
 conda create --quiet --name testing python="%PYTHON%" pip
 
-ECHO
+ECHO.
 ECHO Updating pip
 ECHO ===============================================
 activate testing
 python -m pip install --upgrade pip
 deactivate
 
-ECHO
+ECHO.
 ECHO Installing requirements from file
 ECHO ===============================================
 IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --name testing --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -28,9 +28,10 @@ conda create --quiet --name testing python="%PYTHON%" pip
 ECHO.
 ECHO Updating pip
 ECHO ===============================================
-activate testing
+REM Need to use call in batch scripts: https://github.com/conda/conda/issues/794
+call activate testing
 python -m pip install --upgrade pip
-deactivate
+call deactivate
 
 ECHO.
 ECHO Installing requirements from file

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -7,20 +7,32 @@ VERIFY OTHER 2>nul
 SETLOCAL ENABLEEXTENSIONS
 IF ERRORLEVEL 1 ECHO Unable to enable extensions
 
+ECHO
+ECHO Configuring conda
+ECHO ===============================================
 REM Don't change the prompt or request user input
 conda config --set always_yes yes --set changeps1 no
-
 REM Add conda-forge to the top of the channel list
 conda config --add channels conda-forge
 
+ECHO
 ECHO Updating conda
 ECHO ===============================================
 conda update --quiet conda
 
+ECHO
 ECHO Creating the 'testing' environment
 ECHO ===============================================
 conda create --quiet --name testing python="%PYTHON%" pip
 
+ECHO
+ECHO Updating pip
+ECHO ===============================================
+activate testing
+python -m pip install --upgrade pip
+deactivate
+
+ECHO
 ECHO Installing requirements from file
 ECHO ===============================================
 IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --name testing --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -35,6 +35,6 @@ python -m pip install --upgrade pip
 ECHO.
 ECHO Installing requirements from file
 ECHO ===============================================
-IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)
+IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --channel conda-forge --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)
 
 ENDLOCAL


### PR DESCRIPTION
Make sure appveyor actually installs the requirements.
For some reason, have to use `-c conda-forge` to get conda-forge
packages instead of defaults.
Upgrade pip to avoid errors when installing the package.
Need to use `call` to activate the environment, otherwise the script
crashes.