### PR TITLE
Check that Python is not being upgraded

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,8 @@ init:
     # Add miniconda to the PATH
     - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"
     # The file with the listed requirements to be installed by setup-miniconda.bat
-    - set CONDA_REQUIREMENTS=requirements.txt
+    - set REQUIREMENTS=requirements.txt
+    - set REQUIREMENTS_DEV=requirements-dev.txt
 
 install:
     # Get the Fatiando CI scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ before_install:
     - git clone https://github.com/fatiando/continuous-integration.git
     # Download and install miniconda and setup dependencies
     # Need to source the script to set the PATH variable globaly
-    - source continuous-integration/travis/setup-miniconda.sh
+    #- source continuous-integration/travis/setup-miniconda.sh
+    # We'll use the local version but you should use the line above
+    - source travis/setup-miniconda.sh
     # Show installed pkg information for postmortem diagnostic
     - conda list
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ env:
         #- TWINE_USERNAME=your-user-name
         #
         # The file with the listed requirements to be installed by conda
-        - CONDA_REQUIREMENTS=requirements.txt
+        - REQUIREMENTS=requirements.txt
+        - REQUIREMENTS_DEV=requirements-dev.txt
         #
         # These variables control which actions are performed in a build
         - COVERAGE=false
@@ -39,8 +40,6 @@ matrix:
         - os: linux
           env:
               - PYTHON=3.5
-              # Test to see if the install step is skipped if this is empty
-              - CONDA_REQUIREMENTS=""
         - os: linux
           env:
               - PYTHON=3.6
@@ -51,6 +50,9 @@ matrix:
         - os: osx
           env:
               - PYTHON=3.5
+              # Test to see if the install step is skipped if this is empty
+              - REQUIREMENTS=""
+              - REQUIREMENTS_DEV=""
         - os: osx
           env:
               - PYTHON=3.6

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -35,6 +35,10 @@ python -m pip install --upgrade pip
 ECHO.
 ECHO Installing requirements from file
 ECHO ===============================================
-IF DEFINED CONDA_REQUIREMENTS (conda install --quiet --channel conda-forge --file %CONDA_REQUIREMENTS%) ELSE (ECHO No requirements file set)
+IF DEFINED REQUIREMENTS (conda install --quiet --channel conda-forge --file %REQUIREMENTS%) ELSE (ECHO No requirements file set)
+IF DEFINED REQUIREMENTS_DEV (conda install --quiet --channel conda-forge --file %REQUIREMENTS_DEV%) ELSE (ECHO No requirements file set)
+
+REM Check if the Python version is still correct
+python -c "import sys; assert sys.version_info[:2] == tuple(int(i) for i in '%PYTHON%'.split('.'))"
 
 ENDLOCAL

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -35,11 +35,11 @@ python -m pip install --upgrade pip
 ECHO.
 ECHO Installing requirements from file %REQUIREMENTS%
 ECHO ===============================================
-IF DEFINED REQUIREMENTS (conda install --quiet --channel conda-forge --file %REQUIREMENTS%) ELSE (ECHO No requirements file set)
+IF DEFINED REQUIREMENTS (conda install --quiet --channel conda-forge --file %REQUIREMENTS% python="%PYTHON%") ELSE (ECHO No requirements file set)
 ECHO.
 ECHO Installing requirements from file %REQUIREMENTS_DEV%
 ECHO ===============================================
-IF DEFINED REQUIREMENTS_DEV (conda install --quiet --channel conda-forge --file %REQUIREMENTS_DEV%) ELSE (ECHO No requirements file set)
+IF DEFINED REQUIREMENTS_DEV (conda install --quiet --channel conda-forge --file %REQUIREMENTS_DEV% python="%PYTHON%") ELSE (ECHO No requirements file set)
 
 ECHO.
 ECHO Check that Python really is %PYTHON%

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -33,12 +33,18 @@ ECHO ===============================================
 python -m pip install --upgrade pip
 
 ECHO.
-ECHO Installing requirements from file
+ECHO Installing requirements from file %REQUIREMENTS%
 ECHO ===============================================
 IF DEFINED REQUIREMENTS (conda install --quiet --channel conda-forge --file %REQUIREMENTS%) ELSE (ECHO No requirements file set)
+ECHO.
+ECHO Installing requirements from file %REQUIREMENTS_DEV%
+ECHO ===============================================
 IF DEFINED REQUIREMENTS_DEV (conda install --quiet --channel conda-forge --file %REQUIREMENTS_DEV%) ELSE (ECHO No requirements file set)
 
-REM Check if the Python version is still correct
+ECHO.
+ECHO Check that Python really is %PYTHON%
+ECHO ===============================================
+REM Check if the Python version is still correct after installing all dependencies
 python -c "import sys; assert sys.version_info[:2] == tuple(int(i) for i in '%PYTHON%'.split('.'))"
 
 ENDLOCAL

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-# A sample requirements file for conda
-numpy
+# A sample requirements file for conda development dependencies
+black

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+# A sample requirements file for conda
+numpy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 # A sample requirements file for conda development dependencies
-black
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# A sample requirements file for conda
-numpy
+# A sample requirements file for conda development dependencies
+black

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-# A sample requirements file for conda development dependencies
-black
+# A sample requirements file for conda
+numpy

--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -59,6 +59,9 @@ if [ ! -z "$REQUIREMENTS_DEV" ]; then
     conda install --quiet --file $REQUIREMENTS_DEV
 fi
 
+echo ""
+echo "Check that Python really is $PYTHON"
+echo "========================================================================"
 # Make sure that this is the correct Python version. You probably don't need this.
 python -c "import sys; assert sys.version_info[:2] == tuple(int(i) for i in '$PYTHON'.split('.'))"
 

--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -50,13 +50,13 @@ if [ ! -z "$REQUIREMENTS" ]; then
     echo ""
     echo "Installing requirments from file $REQUIREMENTS"
     echo "========================================================================"
-    conda install --quiet --file $REQUIREMENTS
+    conda install --quiet --file $REQUIREMENTS python=$PYTHON
 fi
 if [ ! -z "$REQUIREMENTS_DEV" ]; then
     echo ""
     echo "Installing requirments from file $REQUIREMENTS_DEV"
     echo "========================================================================"
-    conda install --quiet --file $REQUIREMENTS_DEV
+    conda install --quiet --file $REQUIREMENTS_DEV python=$PYTHON
 fi
 
 echo ""

--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -46,12 +46,21 @@ conda create --quiet --name testing python=$PYTHON pip
 source activate testing
 
 # Install dependencies if a requirements file is specified
-if [ ! -z "$CONDA_REQUIREMENTS" ]; then
+if [ ! -z "$REQUIREMENTS" ]; then
     echo ""
-    echo "Installing requirments from file $CONDA_REQUIREMENTS"
+    echo "Installing requirments from file $REQUIREMENTS"
     echo "========================================================================"
-    conda install --quiet --file $CONDA_REQUIREMENTS
+    conda install --quiet --file $REQUIREMENTS
 fi
+if [ ! -z "$REQUIREMENTS_DEV" ]; then
+    echo ""
+    echo "Installing requirments from file $REQUIREMENTS_DEV"
+    echo "========================================================================"
+    conda install --quiet --file $REQUIREMENTS_DEV
+fi
+
+# Make sure that this is the correct Python version. You probably don't need this.
+python -c "import sys; assert sys.version_info[:2] == tuple(int(i) for i in '$PYTHON'.split('.'))"
 
 # Workaround for https://github.com/travis-ci/travis-ci/issues/6522
 # Turn off exit on failure.


### PR DESCRIPTION
For example, black is 3.6 only so when installing on 3.5 conda will
update Python itself silently. This can be fixed by enforcing the
Python version on the conda install commands. This way, if any
dependency is not compatible we'll at least get an error message.

This is breaking GenericMappingTools/gmt-python#212