### PR TITLE
 Don't use the defaults conda channel 

### DIFF
--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -13,7 +13,8 @@ ECHO ===============================================
 REM Don't change the prompt or request user input
 conda config --set always_yes yes --set changeps1 no
 REM Add conda-forge to the top of the channel list
-conda config --add channels conda-forge
+conda config --prepend channels conda-forge
+conda config --remove channels defaults
 
 ECHO.
 ECHO Updating conda

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,17 @@
 # A sample requirements file for conda development dependencies
+dask
+pyproj
+matplotlib
+cartopy
+jupyter
 pytest
+pytest-cov
+pytest-mpl
+coverage
+pylint
+sphinx
+sphinx_rtd_theme
+sphinx-gallery
+nbsphinx
+numpydoc
+twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 # A sample requirements file for conda
 numpy
+scipy
+pandas
+xarray
+scikit-learn

--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -30,7 +30,8 @@ export PATH="$CONDA_PREFIX/bin:$PATH"
 conda config --set always_yes yes --set changeps1 no
 
 # Add conda-forge to the top of the channel list
-conda config --add channels conda-forge
+conda config --prepend channels conda-forge
+conda config --remove channels defaults
 
 # Update conda to the latest version
 echo ""


### PR DESCRIPTION
The mixture of defaults and conda-forge causes a huge mess (conda/conda#7656). 
Remove the defaults channel from `.condarc` to make sure we don't mix things.
