### PR TITLE
Use variable to give extra dependencies to install

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,10 +12,12 @@ environment:
     matrix:
         - MINICONDA: C:\Miniconda36-x64
           PYTHON: 3.6
-          CONDA_EXTRA_CHANNEL: conda-forge/label/dev
+          CONDA_INSTALL_EXTRA: black flake8
 
         - MINICONDA: C:\Miniconda35-x64
           PYTHON: 3.5
+          CONDA_EXTRA_CHANNEL: conda-forge/label/dev
+
 
 init:
     # Add miniconda to the PATH

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,18 +13,18 @@ environment:
         - MINICONDA: C:\Miniconda36-x64
           PYTHON: 3.6
           CONDA_INSTALL_EXTRA: black flake8
+          CONDA_REQUIREMENTS: requirements.txt
+          CONDA_REQUIREMENTS_DEV: requirements-dev.txt
 
         - MINICONDA: C:\Miniconda35-x64
           PYTHON: 3.5
           CONDA_EXTRA_CHANNEL: conda-forge/label/dev
+          CONDA_REQUIREMENTS: requirements.txt
 
 
 init:
     # Add miniconda to the PATH
     - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"
-    # The file with the listed requirements to be installed by setup-miniconda.bat
-    - set CONDA_REQUIREMENTS=requirements.txt
-    - set CONDA_REQUIREMENTS_DEV=requirements-dev.txt
 
 install:
     # Get the Fatiando CI scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
         #- secure: "JUMBLE OF CHARACTERS"
         #- TWINE_USERNAME=your-user-name
         #
-        # The file with the listed requirements to be installed by conda
+        # These files list the requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
         #
@@ -48,6 +48,8 @@ matrix:
               - BUILD_DOCS=true
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
+              # List extra dependencies that need to be installed in this build
+              - CONDA_INSTALL_EXTRA="black flake8"
         - os: osx
           env:
               - PYTHON=3.5

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -53,8 +53,12 @@ IF DEFINED CONDA_REQUIREMENTS_DEV (
 IF EXIST "%requirements_file%" (
     ECHO Installing collected dependencies:
     TYPE %requirements_file%
-    ECHO %CONDA_INSTALL_EXTRA%
+    IF DEFINED CONDA_REQUIREMENTS_DEV (
+        ECHO %CONDA_INSTALL_EXTRA%
+    )
     conda install --quiet --file %requirements_file% python=%PYTHON% %CONDA_INSTALL_EXTRA%
+) ELSE (
+    ECHO No requirements files defined.
 )
 
 REM Check if the Python version is still correct after installing all dependencies

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -53,7 +53,7 @@ IF DEFINED CONDA_REQUIREMENTS_DEV (
 IF EXIST "%requirements_file%" (
     ECHO Installing collected dependencies:
     TYPE %requirements_file%
-    IF DEFINED CONDA_REQUIREMENTS_DEV (
+    IF DEFINED CONDA_INSTALL_EXTRA (
         ECHO %CONDA_INSTALL_EXTRA%
     )
     conda install --quiet --file %requirements_file% python=%PYTHON% %CONDA_INSTALL_EXTRA%

--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -6,25 +6,25 @@
 # To return a failure if any commands inside fail
 set -e
 
-MINICONDA_URL="http://repo.continuum.io/miniconda"
+miniconda_url="http://repo.continuum.io/miniconda"
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    MINICONDA_FILE=Miniconda3-latest-MacOSX-x86_64.sh
+    miniconda_file=Miniconda3-latest-MacOSX-x86_64.sh
 else
-    MINICONDA_FILE=Miniconda3-latest-Linux-x86_64.sh
+    miniconda_file=Miniconda3-latest-Linux-x86_64.sh
 fi
 
-CONDA_PREFIX=$HOME/miniconda
+conda_prefix=$HOME/miniconda
 
 # Download and install miniconda
 echo ""
-echo "Downloading Miniconda from $MINICONDA_URL/$MINICONDA_FILE"
+echo "Downloading Miniconda from $miniconda_url/$miniconda_file"
 echo "========================================================================"
-wget $MINICONDA_URL/$MINICONDA_FILE -O miniconda.sh
-bash miniconda.sh -b -p $CONDA_PREFIX
+wget $miniconda_url/$miniconda_file -O miniconda.sh
+bash miniconda.sh -b -p $conda_prefix
 
 # Add it to the path
-export PATH="$CONDA_PREFIX/bin:$PATH"
+export PATH="$conda_prefix/bin:$PATH"
 
 echo ""
 echo "Configuring conda"
@@ -60,7 +60,7 @@ source activate testing
 echo ""
 echo "Installing dependencies"
 echo "========================================================================"
-requirements_file = "full-conda-requirements.txt"
+requirements_file=full-conda-requirements.txt
 if [ ! -z "$CONDA_REQUIREMENTS" ]; then
     echo "Capturing dependencies from $CONDA_REQUIREMENTS"
     cat $CONDA_REQUIREMENTS >> $requirements_file

--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -77,6 +77,8 @@ if [ -f $requirements_file ]; then
     cat $requirements_file
     echo $CONDA_INSTALL_EXTRA
     conda install --quiet --file $requirements_file python=$PYTHON $CONDA_INSTALL_EXTRA
+else
+    echo "No requirements files defined."
 fi
 
 # Make sure that this is the correct Python version. Sometimes conda will try to upgrade

--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -56,24 +56,34 @@ echo "========================================================================"
 conda create --quiet --name testing python=$PYTHON pip
 source activate testing
 
-# Install dependencies if a requirements file is specified
+# Install dependencies
+echo ""
+echo "Installing dependencies"
+echo "========================================================================"
+requirements_file = "full-conda-requirements.txt"
 if [ ! -z "$CONDA_REQUIREMENTS" ]; then
-    echo ""
-    echo "Installing requirments from file $CONDA_REQUIREMENTS"
-    echo "========================================================================"
-    conda install --quiet --file $CONDA_REQUIREMENTS python=$PYTHON
+    echo "Capturing dependencies from $CONDA_REQUIREMENTS"
+    cat $CONDA_REQUIREMENTS >> $requirements_file
 fi
 if [ ! -z "$CONDA_REQUIREMENTS_DEV" ]; then
-    echo ""
-    echo "Installing requirments from file $CONDA_REQUIREMENTS_DEV"
-    echo "========================================================================"
-    conda install --quiet --file $CONDA_REQUIREMENTS_DEV python=$PYTHON
+    echo "Capturing dependencies from $CONDA_REQUIREMENTS_DEV"
+    cat $CONDA_REQUIREMENTS_DEV >> $requirements_file
+fi
+if [ -z "$CONDA_INSTALL_EXTRA" ]; then
+    CONDA_INSTALL_EXTRA=""
+fi
+if [ -f $requirements_file ]; then
+    echo "Installing collected dependencies:"
+    cat $requirements_file
+    echo $CONDA_INSTALL_EXTRA
+    conda install --quiet --file $requirements_file python=$PYTHON $CONDA_INSTALL_EXTRA
 fi
 
+# Make sure that this is the correct Python version. Sometimes conda will try to upgrade
+# Python itself if a dependency doesn't support a version. We're enforcing this in the
+# conda install above but it's best to check.
 echo ""
 echo "Check that Python really is $PYTHON"
-echo "========================================================================"
-# Make sure that this is the correct Python version. You probably don't need this.
 python -c "import sys; assert sys.version_info[:2] == tuple(int(i) for i in '$PYTHON'.split('.'))"
 
 # Workaround for https://github.com/travis-ci/travis-ci/issues/6522


### PR DESCRIPTION
The `CONDA_INSTALL_EXTRA` variable specifies extra dependencies to be
installed by the setup scripts. This allows builds to specify extra
dependencies without needing to call conda.
The `CONDA_REQUIREMENTS` and `CONDA_REQUIREMENTS_DEV` files are merged
into a single one before installing and the extra packages are appended
to the same conda install command. This guarantees that everything is
installed by a single `conda install` command. Hopefully this will help
avoid some packages updating without our consent at later conda
installs.