### PR TITLE
Allow users define HTML's build directory

### DIFF
--- a/travis/deploy-gh-pages.sh
+++ b/travis/deploy-gh-pages.sh
@@ -15,7 +15,7 @@ BRANCH=gh-pages
 CLONE_DIR=deploy
 CLONE_ARGS="--quiet --branch=$BRANCH --single-branch"
 REPO_URL=https://${GH_TOKEN}@github.com/${REPO}.git
-HTML_SRC=${TRAVIS_BUILD_DIR}/doc/_build/html
+HTML_SRC=${TRAVIS_BUILD_DIR}/${HTML_BUILDDIR:-doc/_build/html}
 # Place the HTML is different folders for different versions
 if [[ "${TRAVIS_TAG}" != "" ]]; then
     VERSION=${TRAVIS_TAG}


### PR DESCRIPTION
Fixes #10. 
If HTML_BUILDDIR is not defined:

    HTML_SRC=${TRAVIS_BUILD_DIR}/doc/_build/html

else:

    HTML_SRC=${TRAVIS_BUILD_DIR}/${HTML_BUILDDIR}

It's flexible and also backward compatible.