### PR TITLE
Don't remove the defaults conda channel

### DIFF
--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -21,7 +21,6 @@ IF DEFINED CONDA_EXTRA_CHANNEL (
 ) ELSE (
     ECHO Not setting extra channels
 )
-conda config --set channel_priority strict
 conda config --set show_channel_urls True
 
 REM Display all configuration options for diagnosis

--- a/appveyor/setup-miniconda.bat
+++ b/appveyor/setup-miniconda.bat
@@ -15,13 +15,14 @@ conda config --set always_yes yes --set changeps1 no
 
 REM Add conda-forge to the top of the channel list
 conda config --prepend channels conda-forge
-conda config --remove channels defaults
 REM Add an extra channel that may be required
 IF DEFINED CONDA_EXTRA_CHANNEL (
     conda config --append channels %CONDA_EXTRA_CHANNEL%
 ) ELSE (
     ECHO Not setting extra channels
 )
+conda config --set channel_priority strict
+conda config --set show_channel_urls True
 
 REM Display all configuration options for diagnosis
 conda config --show

--- a/azure/setup-miniconda.bat
+++ b/azure/setup-miniconda.bat
@@ -21,7 +21,6 @@ IF DEFINED CONDA_EXTRA_CHANNEL (
 ) ELSE (
     ECHO Not setting extra channels
 )
-conda config --set channel_priority strict
 conda config --set show_channel_urls True
 
 REM Display all configuration options for diagnosis

--- a/azure/setup-miniconda.bat
+++ b/azure/setup-miniconda.bat
@@ -15,13 +15,14 @@ conda config --set always_yes yes --set changeps1 no
 
 REM Add conda-forge to the top of the channel list
 conda config --prepend channels conda-forge
-conda config --remove channels defaults
 REM Add an extra channel that may be required
 IF DEFINED CONDA_EXTRA_CHANNEL (
     conda config --append channels %CONDA_EXTRA_CHANNEL%
 ) ELSE (
     ECHO Not setting extra channels
 )
+conda config --set channel_priority strict
+conda config --set show_channel_urls True
 
 REM Display all configuration options for diagnosis
 conda config --show

--- a/azure/setup-miniconda.sh
+++ b/azure/setup-miniconda.sh
@@ -14,11 +14,12 @@ conda config --set always_yes yes --set changeps1 no
 
 # Add conda-forge to the top of the channel list
 conda config --prepend channels conda-forge
-conda config --remove channels defaults
 # Add an extra channel that may be required
 if [[ ! -z $CONDA_EXTRA_CHANNEL ]]; then
     conda config --append channels $CONDA_EXTRA_CHANNEL
 fi
+conda config --set channel_priority strict
+conda config --set show_channel_urls True
 
 # Display all configuration options for diagnosis
 conda config --show

--- a/azure/setup-miniconda.sh
+++ b/azure/setup-miniconda.sh
@@ -18,7 +18,6 @@ conda config --prepend channels conda-forge
 if [[ ! -z $CONDA_EXTRA_CHANNEL ]]; then
     conda config --append channels $CONDA_EXTRA_CHANNEL
 fi
-conda config --set channel_priority strict
 conda config --set show_channel_urls True
 
 # Display all configuration options for diagnosis

--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -34,11 +34,12 @@ conda config --set always_yes yes --set changeps1 no
 
 # Add conda-forge to the top of the channel list
 conda config --prepend channels conda-forge
-conda config --remove channels defaults
 # Add an extra channel that may be required
 if [[ ! -z $CONDA_EXTRA_CHANNEL ]]; then
     conda config --append channels $CONDA_EXTRA_CHANNEL
 fi
+conda config --set channel_priority strict
+conda config --set show_channel_urls True
 
 # Display all configuration options for diagnosis
 conda config --show

--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -38,7 +38,6 @@ conda config --prepend channels conda-forge
 if [[ ! -z $CONDA_EXTRA_CHANNEL ]]; then
     conda config --append channels $CONDA_EXTRA_CHANNEL
 fi
-conda config --set channel_priority strict
 conda config --set show_channel_urls True
 
 # Display all configuration options for diagnosis


### PR DESCRIPTION
Since conda-forge migrated compilers, conflicts with defaults aren't a
big issue anymore. There is no reason to remove the defaults channel.
This might actually cause trouble down the line when conda-forge uses
some defaults packages as dependencies (like the compiler and base
library packages).