### PR TITLE
Fix conda permission error on Azure Mac builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -40,6 +40,11 @@ jobs:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
 
+  # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation directory/
+  # We need to take ownership if we want to update conda or install packages globally
+  #- bash: sudo chown -R $USER $CONDA
+    #displayName: Take ownership of conda installation
+
   # Get the Fatiando CI scripts (replace "master" with the version you want to use)
   - bash: git clone --branch=master --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -40,10 +40,11 @@ jobs:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
 
-  # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation directory/
-  # We need to take ownership if we want to update conda or install packages globally
-  #- bash: sudo chown -R $USER $CONDA
-    #displayName: Take ownership of conda installation
+  # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation
+  # directory. We need to take ownership if we want to update conda or install packages
+  # globally.
+  - bash: sudo chown -R $USER $CONDA
+    displayName: Take ownership of conda installation
 
   # Get the Fatiando CI scripts (replace "master" with the version you want to use)
   - bash: git clone --branch=master --depth=1 https://github.com/fatiando/continuous-integration.git


### PR DESCRIPTION
Conda is complaining about persmission errors when trying to update conda itself. Add
configuration from
[the Azure docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/anaconda?view=azure-devops&tabs=macos)
to allow it to do it's thing.