### PR TITLE
Don't update conda on TravisCI builds

### DIFF
--- a/travis/setup-miniconda.sh
+++ b/travis/setup-miniconda.sh
@@ -43,12 +43,6 @@ conda config --set show_channel_urls True
 # Display all configuration options for diagnosis
 conda config --show
 
-# Update conda to the latest version
-echo ""
-echo "Updating conda"
-echo "========================================================================"
-conda update --quiet conda
-
 # Create and activate an environment for testing
 echo ""
 echo "Creating the 'testing' environment with python=$PYTHON"


### PR DESCRIPTION
Avoid updating conda during setup to prevent things breaking from bad
conda upgrades. Let conda update only when Miniconda makes a new
release so we have more stable builds.

Fixes #21